### PR TITLE
shift length extension to 6 hrs

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -53,7 +53,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/lockdown = FALSE	//disallow transit after nuke goes off
 
-	var/auto_call = 72000 //CIT CHANGE - time before in deciseconds in which the shuttle is auto called. Default is 2ish hours plus 15 for the shuttle. So total is 3.
+	var/auto_call = 216000 //WZDS Change - increased the auto-call timer to ~6 hours
 	var/realtimeofstart = 0
 
 /datum/controller/subsystem/shuttle/Initialize(timeofday)
@@ -76,7 +76,7 @@ SUBSYSTEM_DEF(shuttle)
 	if(!supply)
 		WARNING("No /obj/docking_port/mobile/supply placed on the map!")
 	realtimeofstart = world.realtime
-	auto_call = CONFIG_GET(number/auto_transfer_delay)
+	auto_call = 216000
 	return ..()
 
 /datum/controller/subsystem/shuttle/proc/initial_load()

--- a/modular_citadel/code/controllers/subsystem/shuttle.dm
+++ b/modular_citadel/code/controllers/subsystem/shuttle.dm
@@ -1,6 +1,6 @@
 /datum/controller/subsystem/shuttle/proc/autoEnd() //CIT CHANGE - allows shift to end after 3 hours has passed.
 	if((world.realtime - SSshuttle.realtimeofstart) > auto_call && EMERGENCY_IDLE_OR_RECALLED) //3 hours
 		SSshuttle.emergency.request()
-		priority_announce("The shift has come to an end and the shuttle called.")
+		priority_announce("The shift has come to an end and the shuttle called. Have a safe trip.")
 		log_game("Round time limit reached. Shuttle has been auto-called.")
 		message_admins("Round time limit reached. Shuttle called.")


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: shift length extention
code: changed shift length to 6 hours. Properly this time.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

2 hours is just not long enough for us. 6 is much better for what we want to do. Shifts can end early if they need to anyways.