### PR TITLE
Remove suit voucher

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -22,3 +22,6 @@
 	new /obj/item/circuitboard/machine/techfab/department/cargo(src)
 	new /obj/item/storage/photo_album/QM(src)
 	new /obj/item/circuitboard/machine/ore_silo(src)
+	new /obj/item/suit_voucher(src)
+	new /obj/item/suit_voucher(src)
+	new /obj/item/suit_voucher(src)

--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -93,7 +93,6 @@ Shaft Miner
 		/obj/item/storage/bag/ore=1,\
 		/obj/item/kitchen/knife/combat/survival=1,\
 		/obj/item/mining_voucher=1,\
-		/obj/item/suit_voucher=1,\
 		/obj/item/stack/marker_beacon/ten=1)
 
 	backpack = /obj/item/storage/backpack/explorer


### PR DESCRIPTION
[Changelogs]:

Phi
balance: removed miner suit voucher
/:cl:

[why]:
having a suit voucher to get an upgraded suit off the bat is a little OP, and takes away from earning better equipment as a miner.
