### PR TITLE
Reduce shift time from 6 hrs to 4.

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -53,7 +53,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/lockdown = FALSE	//disallow transit after nuke goes off
 
-	var/auto_call = 216000 //WZDS Change - increased the auto-call timer to ~6 hours
+	var/auto_call = 144000 //WZDS Change - shift time is ~4 hrs.
 	var/realtimeofstart = 0
 
 /datum/controller/subsystem/shuttle/Initialize(timeofday)


### PR DESCRIPTION
[Changelogs]:
:cl: Phi
tweak: changed shift time limit to 4 hours instead of 6.
/:cl:

[why]: 6hrs is a bit much now we actually have players. 4hrs is more balanced. This may change in the future depending on changes/additions (future gamemodes for e.g.)
