### PR TITLE
Alt ctrl pipes tg

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -27,7 +27,26 @@ Thus, the two variables affect pump operation are set in New():
 
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "pump"
-
+	
+/obj/machinery/atmospherics/components/binary/pump/CtrlClick(mob/user)
+	var/area/A = get_area(src)
+	var/turf/T = get_turf(src)
+	if(user.canUseTopic(src, BE_CLOSE, FALSE,))
+		on = !on
+		update_icon()
+		investigate_log("Pump, [src.name], turned on by [key_name(usr)] at [x], [y], [z], [A]", INVESTIGATE_ATMOS)
+		message_admins("Pump, [src.name], turned [on ? "on" : "off"] by [ADMIN_LOOKUPFLW(usr)] at [ADMIN_COORDJMP(T)], [A]")
+		return ..()
+	
+/obj/machinery/atmospherics/components/binary/pump/AltClick(mob/user)
+	var/area/A = get_area(src)
+	var/turf/T = get_turf(src)
+	if(user.canUseTopic(src, BE_CLOSE, FALSE,))
+		target_pressure = MAX_OUTPUT_PRESSURE
+		to_chat(user,"<span class='notice'>You maximize the pressure on the [src].</span>")
+		investigate_log("Pump, [src.name], was maximized by [key_name(usr)] at [x], [y], [z], [A]", INVESTIGATE_ATMOS)
+		message_admins("Pump, [src.name], was maximized by [ADMIN_LOOKUPFLW(usr)] at [ADMIN_COORDJMP(T)], [A]")
+		
 /obj/machinery/atmospherics/components/binary/pump/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -28,6 +28,16 @@ Thus, the two variables affect pump operation are set in New():
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "volumepump"
 
+/obj/machinery/atmospherics/components/binary/volume_pump/CtrlClick(mob/user)
+	var/area/A = get_area(src)
+	var/turf/T = get_turf(src)
+	if(user.canUseTopic(src, BE_CLOSE, FALSE,))
+		on = !on
+		update_icon()
+		investigate_log("Pump, [src.name], turned on by [key_name(usr)] at [x], [y], [z], [A]", INVESTIGATE_ATMOS)
+		message_admins("Pump, [src.name], turned [on ? "on" : "off"] by [ADMIN_LOOKUPFLW(usr)] at [ADMIN_COORDJMP(T)], [A]")
+		return ..()
+		
 /obj/machinery/atmospherics/components/binary/volume_pump/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -12,6 +12,25 @@
 	construction_type = /obj/item/pipe/trinary/flippable
 	pipe_state = "filter"
 
+/obj/machinery/atmospherics/components/trinary/filter/CtrlClick(mob/user)
+	var/area/A = get_area(src)
+	var/turf/T = get_turf(src)
+	if(user.canUseTopic(src, BE_CLOSE, FALSE,))
+		on = !on
+		update_icon()
+		investigate_log("Pump, [src.name], turned on by [key_name(usr)] at [x], [y], [z], [A]", INVESTIGATE_ATMOS)
+		message_admins("Pump, [src.name], turned [on ? "on" : "off"] by [ADMIN_LOOKUPFLW(usr)] at [ADMIN_COORDJMP(T)], [A]")
+		return ..()
+		
+/obj/machinery/atmospherics/components/trinary/filter/AltClick(mob/user)
+	var/area/A = get_area(src)
+	var/turf/T = get_turf(src)
+	if(user.canUseTopic(src, BE_CLOSE, FALSE,))
+		target_pressure = MAX_OUTPUT_PRESSURE
+		to_chat(user,"<span class='notice'>You maximize the pressure on the [src].</span>")
+		investigate_log("Pump, [src.name], was maximized by [key_name(usr)] at [x], [y], [z], [A]", INVESTIGATE_ATMOS)
+		message_admins("Pump, [src.name], was maximized by [ADMIN_LOOKUPFLW(usr)] at [ADMIN_COORDJMP(T)], [A]")
+		
 /obj/machinery/atmospherics/components/trinary/filter/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -14,7 +14,25 @@
 	pipe_state = "mixer"
 
 	//node 3 is the outlet, nodes 1 & 2 are intakes
-
+/obj/machinery/atmospherics/components/trinary/mixer/CtrlClick(mob/user)
+	var/area/A = get_area(src)
+	var/turf/T = get_turf(src)
+	if(user.canUseTopic(src, BE_CLOSE, FALSE,))
+		on = !on
+		update_icon()
+		investigate_log("Pump, [src.name], turned on by [key_name(usr)] at [x], [y], [z], [A]", INVESTIGATE_ATMOS)
+		message_admins("Pump, [src.name], turned [on ? "on" : "off"] by [ADMIN_LOOKUPFLW(usr)] at [ADMIN_COORDJMP(T)], [A]")
+		return ..()
+		
+/obj/machinery/atmospherics/components/trinary/mixer/AltClick(mob/user)
+	var/area/A = get_area(src)
+	var/turf/T = get_turf(src)
+	if(user.canUseTopic(src, BE_CLOSE, FALSE,))
+		target_pressure = MAX_OUTPUT_PRESSURE
+		to_chat(user,"<span class='notice'>You maximize the pressure on the [src].</span>")
+		investigate_log("Pump, [src.name], was maximized by [key_name(usr)] at [x], [y], [z], [A]", INVESTIGATE_ATMOS)
+		message_admins("Pump, [src.name], was maximized by [ADMIN_LOOKUPFLW(usr)] at [ADMIN_COORDJMP(T)], [A]")
+		
 /obj/machinery/atmospherics/components/trinary/mixer/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X


### PR DESCRIPTION
🆑
add: You can now use CTRL and ALT click on pumps and filters to toggle them on and off and max their output respectively
/🆑

Ported from tgstation/tgstation#42863 with a few edits for compability.
Its my first PR, so please tell me if i did something wrong.
I think this feature would help anyone and everyone doing atmospherics, as it makes pumps way easier to use, and you wont need to open the interface to use pumps anymore, which can often bug out.