### PR TITLE
Adds Neurine back to chemistry

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -829,7 +829,15 @@
 
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/C)
 	C.adjustBrainLoss(-2*REM)
-	if(prob(10))
+	..()
+
+/datum/reagent/medicine/neurine
+	name = "Neurine"
+	id = "neurine"
+	description = "Reacts with neural tissue, helping reform damaged connections. Can cure minor traumas."
+	color = "#EEFF8F"
+/datum/reagent/medicine/neurine/on_mob_life(mob/living/carbon/C)
+	if(prob(15))
 		C.cure_trauma_type(resilience = TRAUMA_RESILIENCE_BASIC)
 	..()
 

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -166,6 +166,12 @@
 	required_reagents = list("sugar" = 1, "hydrogen" = 1, "water" = 1)
 	mix_message = "The solution slightly bubbles, becoming thicker."
 
+ /datum/chemical_reaction/neurine
+	name = "Neurine"
+	id = "neurine"
+	results = list("neurine" = 3)
+	required_reagents = list("mannitol" = 1, "acetone" = 1, "oxygen" = 1)
+
 /datum/chemical_reaction/mutadone
 	name = "Mutadone"
 	id = "mutadone"


### PR DESCRIPTION
[Changelogs]: 
:cl: Phi
add: Adds Neurine back to chemistry
/:cl:

[why]: Mannitol is too easy to make and isn't effective enough. Having people make Neurine to fix brain traumas more effectively makes sense. No idea why this was removed.
