### PR TITLE
makes the notify command actually work.

### DIFF
--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -78,13 +78,13 @@ GLOBAL_LIST(round_end_notifiees)
 /datum/tgs_chat_command/notify
 	name = "notify"
 	help_text = "Pings the invoker when the round ends"
-	admin_only = TRUE
+	admin_only = FALSE
 
 /datum/tgs_chat_command/notify/Run(datum/tgs_chat_user/sender, params)
 	if(!SSticker.IsRoundInProgress() && SSticker.HasRoundStarted())
 		return "[sender.mention], the round has already ended!"
 	LAZYINITLIST(GLOB.round_end_notifiees)
-	GLOB.round_end_notifiees[sender.mention] = TRUE
+	GLOB.round_end_notifiees["<@[sender.mention]>"] = TRUE
 	return "I will notify [sender.mention] when the round ends."
 
 /datum/tgs_chat_command/sdql


### PR DESCRIPTION
:cl: Phi
fix: the chat bot notify command actually works now and is accessible for everyone.
/:cl:

[why]: it didn't work, now it does. and everyone can use it not just admins.
